### PR TITLE
MKTG-2413-added 0.8 version

### DIFF
--- a/_includes/homepage_top.html
+++ b/_includes/homepage_top.html
@@ -28,6 +28,8 @@
     </div>
 
     <div class="gap">
-        <a href ="https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/" target="_blank" class="raml-links">Read the Specification</a>
+        <a href ="https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/" target="_blank" class="raml-links">RAML 1.0 Specification</a><br />
+        <br />
+        <a href ="https://github.com/raml-org/raml-spec/blob/master/versions/raml-08/raml-08.md" target="_blank" class="ramlnewlink">RAML 0.8 Specification</a>
     </div>
 </section>

--- a/_includes/homepage_top.html
+++ b/_includes/homepage_top.html
@@ -30,6 +30,6 @@
     <div class="gap">
         <a href ="https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md/" target="_blank" class="raml-links">RAML 1.0 Specification</a><br />
         <br />
-        <a href ="https://github.com/raml-org/raml-spec/blob/master/versions/raml-08/raml-08.md" target="_blank" class="ramlnewlink">RAML 0.8 Specification</a>
+        <a href ="https://github.com/raml-org/raml-spec/blob/master/versions/raml-08/raml-08.md" target="_blank" class="ramloldlink">RAML 0.8 Specification</a>
     </div>
 </section>

--- a/css/style.scss
+++ b/css/style.scss
@@ -2302,7 +2302,7 @@ section.projectlinks {
   width: 253.5px
 }
 
-a.ramlnewlink {
+a.ramloldlink {
   font-size: 12px;
   color: #fff;
 

--- a/css/style.scss
+++ b/css/style.scss
@@ -2301,3 +2301,13 @@ section.projectlinks {
   top:20px;
   width: 253.5px
 }
+
+a.ramlnewlink {
+  font-size: 12px;
+  color: #fff;
+
+  &:hover {
+    text-decoration: none;
+    color: #ffffff;
+  }
+}


### PR DESCRIPTION
Hi,

On the RAML home page only we want to have both the 0.8 and 1.0 version of the spec. Should have one blue icon copy "RAML 1.0 Specification" and then white copy below in smaller font, "RAML 0.8 Specification"

![screen shot 2017-07-05 at 3 16 12 pm](https://user-images.githubusercontent.com/498114/28059814-55f7dc14-661d-11e7-8401-d85244d85031.png)

Thank you,
S.P.Sriharsha