### PR TITLE
RAML-to-Swagger2-Converter-Java

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -17,6 +17,14 @@
   url: https://github.com/raml2html/raml2html
   topics:
     - Document
+- name: RAML-to-Swagger2-converter
+  author: eshwanth
+  description: |
+    The goal of RAML-to-Swagger-converter is to provide a tool (in this case, a java project) 
+    which supports converting RAML 0.8 API definition to Swagger 2.0 API definition.
+  url: https://github.com/esh-b/RAML-to-Swagger-Converter
+  topics:
+    - Utilities
 - name: raml-json-api
   author: Arthur
   description: |


### PR DESCRIPTION
- It is a java project which converts RAML 0.8 version of API definitions to Swagger 2.0 API definitions. This ensures RAML's backward compatibility with Swagger. Java is being used by majority of the corporate companies. So, this java project might help them to do the interconversion with ease.

- All the dependencies, examples and the instructions to run the project are described in the readme.md file in the project directory.

Regards,
Eshwanth.