### PR TITLE
Include parameters in resourceTypes example

### DIFF
--- a/raml-200-tutorial.html
+++ b/raml-200-tutorial.html
@@ -286,7 +286,7 @@ permalink: /developers/raml-200-tutorial
       queryParameters:
         access_token:
           description: &quot;The access token provided by the authentication application&quot;
-          example: AABBCCDD 
+          example: AABBCCDD
           required: true
           type: string
       body:
@@ -324,7 +324,7 @@ permalink: /developers/raml-200-tutorial
       queryParameters:
         access_token:
           description: &quot;The access token provided by the authentication application&quot;
-          example: AABBCCDD 
+          example: AABBCCDD
           required: true
           type: string
       body:
@@ -453,28 +453,26 @@ permalink: /developers/raml-200-tutorial
         200:
           body:
             application/json:
-              example: |
-                &lt;&lt;exampleCollection&gt;&gt;
+              example: &lt;&lt;exampleCollection&gt;&gt;
     post:
       description: |
         Add a new &lt;&lt;resourcePathName|!singularize&gt;&gt; to Jukebox.
       queryParameters:
         access_token:
           description: &quot;The access token provided by the authentication application&quot;
-          example: AABBCCDD 
+          example: AABBCCDD
           required: true
           type: string
       body:
         application/json:
           type: &lt;&lt;resourcePathName|!singularize&gt;&gt;
-          example: |
-            &lt;&lt;exampleItem&gt;&gt;
+          example: &lt;&lt;exampleItem&gt;&gt;
       responses:
         200:
           body:
             application/json:
-              example: |
-                &lt;&lt;exampleItem&gt;&gt;
+              example:
+                { &quot;message&quot;: &quot;The &lt;&lt;resourcePathName|!singularize&gt;&gt; has been properly entered&quot; }
   collection-item:
     description: Entity representing a &lt;&lt;resourcePathName|!singularize&gt;&gt;
     get:

--- a/raml-200-tutorial.html
+++ b/raml-200-tutorial.html
@@ -467,6 +467,8 @@ permalink: /developers/raml-200-tutorial
       body:
         application/json:
           type: &lt;&lt;resourcePathName|!singularize&gt;&gt;
+          example: |
+            &lt;&lt;exampleItem&gt;&gt;
       responses:
         200:
           body:

--- a/raml-200-tutorial.html
+++ b/raml-200-tutorial.html
@@ -453,6 +453,8 @@ permalink: /developers/raml-200-tutorial
         200:
           body:
             application/json:
+              example: |
+                &lt;&lt;exampleCollection&gt;&gt;
     post:
       description: |
         Add a new &lt;&lt;resourcePathName|!singularize&gt;&gt; to Jukebox.
@@ -470,7 +472,7 @@ permalink: /developers/raml-200-tutorial
           body:
             application/json:
               example: |
-                { &quot;message&quot;: &quot;The &lt;&lt;resourcePathName|!singularize&gt;&gt; has been properly entered&quot; }
+                &lt;&lt;exampleItem&gt;&gt;
   collection-item:
     description: Entity representing a &lt;&lt;resourcePathName|!singularize&gt;&gt;
     get:
@@ -614,7 +616,7 @@ permalink: /developers/raml-200-tutorial
         collection:
           exampleCollection: !include jukebox-include-artist-albums.sample
           exampleItem: {}
-      description: Collection of albulms belonging to the artist
+      description: Collection of albums belonging to the artist
       get:
         description: Get a specific artist&#39;s albums list
 </code></pre>


### PR DESCRIPTION
  The text following the example states

> As you can see, the same concept shown in the previous example was applied to both the /songs, and /songs/{songId} resources. In a previous example, the code that was repeated at the end and is now completely within the resourceType at the point that the POST definition directly disappeared from the resources. That's correct. Now, every collection-item typed resources will have a valid (generic) POST definition without you ever writing it.

However, the `exampleCollection` and `exampleItem` perameters weren't actually used in the RAML definition. This fixes that.