### PR TITLE
add cookiecutter-raml template to projects

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -922,3 +922,11 @@
   url: http://www.vrap.io/
   topics:
     - Test
+- name: cookiecutter-raml
+  author: genzj
+  description: |
+    Cookiecutter template for creating a RAML 1.0 project.
+  url: https://github.com/genzj/cookiecutter-raml
+  topics:
+    - Design
+    - Utilities


### PR DESCRIPTION
Cookiecutter is a widely used command-line utility that creates projects from templates. I create a template for creating raml 1.0 projects. It will save much time from repeating the boilerplate code and environment setting up.