### PR TITLE
Adding outbound link tracking in GA

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,6 +11,7 @@
     <script src="{{ site.baseurl }}/js/jquery.min.js"></script>
     <script src="{{ site.baseurl }}/js/bootstrap.min.js"></script>
     <script src="{{ site.baseurl }}/js/script.js"></script>
+	
     {% if page.title == 'Welcome' %}
     <script type="text/javascript">
         $(document).ready(function() {
@@ -61,7 +62,14 @@
         })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
         ga('create', 'UA-44483523-1', 'auto');
         ga('send', 'pageview');
+		var a = document.getElementsByTagName(‘a’);
+		for(i = 0; i < a.length; i++){
+		if (a[i].href.indexOf(location.host) == -1 && a[i].href.match(/^http:///i)){
+		a[i].onclick = function(){
+		_gaq.push([‘_trackEvent’, ‘outgoing_links’, this.href.replace(/^http:///i, ”)]);
+		}
+		}
+		}
     </script>
 </head>
 <body class="{{ page.title | downcase | replace:' ','-' | replace:',','' | strip_html }} {{ page.layout }} {{ page.is_post }}">
-

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -54,22 +54,22 @@
         });
     </script>
     {% endif %}
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function()
-                { (i[r].q=i[r].q||[]).push(arguments)}
-                ,i[r].l=1*new Date();a=s.createElement(o),
-                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-        ga('create', 'UA-44483523-1', 'auto');
-        ga('send', 'pageview');
-		var a = document.getElementsByTagName(‘a’);
-		for(i = 0; i < a.length; i++){
-		if (a[i].href.indexOf(location.host) == -1 && a[i].href.match(/^http:///i)){
-		a[i].onclick = function(){
-		_gaq.push([‘_trackEvent’, ‘outgoing_links’, this.href.replace(/^http:///i, ”)]);
-		}
-		}
-		}
-    </script>
+	<script>
+	       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function()
+	               { (i[r].q=i[r].q||[]).push(arguments)}
+	               ,i[r].l=1*new Date();a=s.createElement(o),
+	               m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+	       })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+	       ga('create', 'UA-44483523-1', 'auto');
+	       ga('send', 'pageview');
+	        var a = document.getElementsByTagName('a');
+	        for(i = 0; i < a.length; i++){
+	        if(a[i].href.indexOf(location.host) == -1 && /^((http|https):\/\/)/.test(a[i].href)){
+	        a[i].onclick = function(){
+	        _gaq.push(['_trackEvent', 'outgoing_links', this.href.replace(/^((http|https):\/\/)/, '')]);
+	        }
+	        }
+	        }
+	   </script>
 </head>
 <body class="{{ page.title | downcase | replace:' ','-' | replace:',','' | strip_html }} {{ page.layout }} {{ page.is_post }}">


### PR DESCRIPTION
Adding outbound link tracking in GA; found out we can’t do this in GTM
because GTM is blocked in Mainland China. This code should show all outbound links on the RAML site including the links to the RAML 1.0 and 0.8 specs.