### PR TITLE
Fix squished words in projects descriptions

### DIFF
--- a/project.json
+++ b/project.json
@@ -6,7 +6,7 @@
     "name"    : "{{ projects.name }}",
     "url"     : "{{ projects.url }}",
     "author"     : "{{ projects.author }}",
-    "description"     : "{{ projects.description | escape | strip_newlines }}",
+    "description"     : "{{ projects.description | escape | replace: '\n', ' ' | strip }}",
     "topics"     : "{{ projects.topics | join: ', ' }}"
   }
 {% if forloop.last %}{% else %},{% endif %}


### PR DESCRIPTION
Go to https://raml.org/projects and search for `thatvisually`. That's how `strip_newlines` filter replaces newlines across all projects descriptions.

This PR uses `replace: '\n', ' ' | strip` instead of `strip_newlines` to replace newlines with spaces instead of blank spaces.

Done similar to this https://github.com/jekyll/jekyll-feed/pull/67/files