### PR TITLE
fix z-index issue with GDPR banner

### DIFF
--- a/css/gdpr-cookie.css
+++ b/css/gdpr-cookie.css
@@ -9,6 +9,7 @@
     padding: 1rem 1rem 1rem 3rem;
     background: black;
     opacity: .85;
+	z-index:110;
 }
 .gdprcookie h1,
 .gdprcookie h2 {


### PR DESCRIPTION
I had to add a z-index to fix the hover hexes floating above the GDPR banner.