### PR TITLE
279510251 Icons on RAML home page get out of alignment on smaller scr…

### DIFF
--- a/css/style.scss
+++ b/css/style.scss
@@ -1866,6 +1866,14 @@ nav.navbar ul {
   right: 32px;
   z-index:100;
   display:none;
+
+  @media screen and (max-width:1199px) and (min-width:768px){
+    right:-5px;
+  }
+
+  @media screen and (max-width:767px){
+    right:8px;
+  }
 }
 
 #one_document_img {
@@ -1877,6 +1885,14 @@ nav.navbar ul {
   right: 69px;
   z-index:100;
   display:none;
+
+  @media screen and (max-width:1199px) and (min-width:768px){
+    right:30px;
+  }
+
+  @media screen and (max-width:767px){
+    right:43px;
+  }
 }
 
 

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@ title:  'Welcome'
 <section class="map-container">
   <div class="container">
     <div class="row">
-      <div class="col-md-5">
+      <div class="col-md-5 col-sm-5">
         <img src="images/map.jpg" usemap="#image-map" height="410">
 
         <map name="image-map" id="imagemap">
@@ -46,7 +46,7 @@ title:  'Welcome'
         <div class="hmapimg" id="one_share_img"></div>
         <div class="hmapimg" id="one_design_img"></div>
       </div>
-      <div class="col-md-7">
+      <div class="col-md-7 col-sm-7">
         <section id="design_desc">
           <h2>Use RAML to Design Your API</h2>
           <div style="height: 150px; overflow: hidden; margin: 30px 0;"><img src="images/design_editor.png" style="margin-top: -10px;" /></div>


### PR DESCRIPTION
On the RAML home page, the icons in the 4th panel: "Document" and "Test" are out of alignment on hover at smaller breakpoints