### PR TITLE
Point to learn_raml instead of starter_guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@ title:  'Welcome'
     hoverUtils.fetchText('examples/world-music-api/api.raml')
       .then(text => editor.getModel().setValue(text))
 
-    const PLAYGROUND_URL = 'https://raml-org.github.io/playground/starter_guide.html';
+    const PLAYGROUND_URL = 'https://raml-org.github.io/playground/learn_raml.html';
     const buttons = document.getElementsByClassName('try-it-out-btn');
     Array.from(buttons).forEach((btn) => {
       btn.onclick = () => {


### PR DESCRIPTION
According to changes done in https://github.com/raml-org/playground/issues/27

>  rename the example "Starter Guide" to "Learn RAML" and make it the default example (first in dropdown)